### PR TITLE
feat: Integrate Giscus for blog post comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,7 +109,7 @@ toc: true
 
 comments:
   # Global switch for the post-comment system. Keeping it empty means disabled.
-  provider: # [disqus | utterances | giscus]
+  provider: giscus # [disqus | utterances | giscus]
   # The provider options are as follows:
   disqus:
     shortname: # fill with the Disqus shortname. › https://help.disqus.com/en/articles/1717111-what-s-a-shortname
@@ -119,15 +119,15 @@ comments:
     issue_term: # < url | pathname | title | ...>
   # Giscus options › https://giscus.app
   giscus:
-    repo: # <gh-username>/<repo>
-    repo_id:
-    category:
-    category_id:
-    mapping: # optional, default to 'pathname'
-    strict: # optional, default to '0'
-    input_position: # optional, default to 'bottom'
-    lang: # optional, default to the value of `site.lang`
-    reactions_enabled: # optional, default to the value of `1`
+    repo: sudhir45/sudhir45.github.io # <gh-username>/<repo>
+    repo_id: R_kgDOOctzzg
+    category: General
+    category_id: DIC_kwDOOctzzs4CpfNr
+    mapping: pathname # optional, default to 'pathname'
+    strict: 0 # optional, default to '0'
+    input_position: bottom # optional, default to 'bottom'
+    lang: en # optional, default to the value of `site.lang`
+    reactions_enabled: 1 # optional, default to the value of `1`
 
 # Self-hosted static assets, optional › https://github.com/cotes2020/chirpy-static-assets
 assets:


### PR DESCRIPTION
Enables Giscus as the comment provider for blog posts.

Configuration changes in `_config.yml`:
- Sets `comments.provider` to `giscus`.
- Populates `comments.giscus` with the repository, repo_id, category, and category_id based on your giscus.app setup.
- Uses default values for mapping, strictness, input position, language, and reactions.

Verification confirmed that the Giscus client script is correctly loaded on post pages.