### PR TITLE
feat: Add RSS feed capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "jekyll-theme-chirpy", "~> 7.2", ">= 7.2.4"
+gem "jekyll-feed", "~> 0.17"
 
 gem "html-proofer", "~> 5.0", group: :test
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ lang: en
 # Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
 timezone: Asia/Kolkata
 
+plugins:
+  - jekyll-feed
+
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
 # ↓ --------------------------
 


### PR DESCRIPTION
Adds the `jekyll-feed` plugin to enable an RSS feed for the site.

- Added `jekyll-feed` to the `Gemfile`.
- Added `jekyll-feed` to the `plugins` array in `_config.yml`.

This will generate a `feed.xml` file and include a link to it in the HTML head, allowing to subscribe to site updates.