### PR TITLE
Some improvements , SEO, Robots.txt

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,128 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta
+    name="viewport"
+    content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+  >
+
+  {%- capture seo_tags -%}
+    {% seo title=false %}
+  {%- endcapture -%}
+
+  <!-- Setup Open Graph image -->
+
+  {% if page.image %}
+    {% assign src = page.image.path | default: page.image %}
+
+    {% unless src contains '://' %}
+      {%- capture img_url -%}
+        {% include media-url.html src=src subpath=page.media_subpath absolute=true %}
+      {%- endcapture -%}
+
+      {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
+      {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
+
+      {% assign seo_tags = seo_tags | replace: old_url, new_url %}
+    {% endunless %}
+
+  {% elsif site.social_preview_image %}
+    {%- capture img_url -%}
+      {% include media-url.html src=site.social_preview_image absolute=true %}
+    {%- endcapture -%}
+
+    {%- capture og_image -%}
+      <meta property="og:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {%- capture twitter_image -%}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta property="twitter:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {% assign old_meta_clip = '<meta name="twitter:card" content="summary" />' %}
+    {% assign new_meta_clip = og_image | append: twitter_image %}
+    {% assign seo_tags = seo_tags | replace: old_meta_clip, new_meta_clip %}
+  {% endif %}
+
+  {{ seo_tags }}
+
+  {% if page.keywords %}<meta name="keywords" content="{% if page.keywords is String %}{{ page.keywords | escape }}{% else %}{{ page.keywords | join: ', ' | escape }}{% endif %}">{% endif %}
+
+  <title>
+    {%- unless page.layout == 'home' -%}
+      {{ page.title | append: ' | ' }}
+    {%- endunless -%}
+    {{ site.title }}
+  </title>
+
+  {% include_cached favicons.html %}
+
+  <!-- Resource Hints -->
+  {% unless site.assets.self_host.enabled %}
+    {% for hint in site.data.origin.cors.resource_hints %}
+      {% for link in hint.links %}
+        <link rel="{{ link.rel }}" href="{{ hint.url }}" {{ link.opts | join: ' ' }}>
+      {% endfor %}
+    {% endfor %}
+  {% endunless %}
+
+  <!-- Bootstrap -->
+  {% unless jekyll.environment == 'production' %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css">
+  {% endunless %}
+
+  <!-- Theme style -->
+  <link rel="stylesheet" href="{{ '/assets/css/:THEME.css' | replace: ':THEME', site.theme | relative_url }}">
+
+  <!-- Web Font -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].webfonts | relative_url }}">
+
+  <!-- Font Awesome Icons -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].fontawesome.css | relative_url }}">
+
+  <!-- 3rd-party Dependencies -->
+
+  {% if site.toc and page.toc %}
+    <link rel="stylesheet" href="{{ site.data.origin[type].toc.css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' %}
+    <link rel="stylesheet" href="{{ site.data.origin[type]['lazy-polyfill'].css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'page' or page.layout == 'post' %}
+    <!-- Image Popup -->
+    <link rel="stylesheet" href="{{ site.data.origin[type].glightbox.css | relative_url }}">
+  {% endif %}
+
+  <!-- Scripts -->
+
+  <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
+
+  {% include js-selector.html lang=lang %}
+
+  {% if jekyll.environment == 'production' %}
+    <!-- PWA -->
+    {% if site.pwa.enabled %}
+      <script
+        defer
+        src="{{ '/app.min.js' | relative_url }}?baseurl={{ site.baseurl | default: '' }}&register={{ site.pwa.cache.enabled }}"
+      ></script>
+    {% endif %}
+
+    <!-- Web Analytics -->
+    {% for analytics in site.analytics %}
+      {% capture str %}{{ analytics }}{% endcapture %}
+      {% assign platform = str | split: '{' | first %}
+      {% if site.analytics[platform].id and site.analytics[platform].id != empty %}
+        {% include analytics/{{ platform }}.html %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% include metadata-hook.html %}
+</head>

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,45 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "{{ page.title | escape }}",
+  "author": {
+    "@type": "Person",
+    "name": "{{ site.social.name | escape }}"
+  },
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  {% if page.last_modified_at %}
+  "dateModified": "{{ page.last_modified_at | date_to_xmlschema }}",
+  {% else %}
+  "dateModified": "{{ page.date | date_to_xmlschema }}",
+  {% endif %}
+  "description": "{{ page.description | escape }}",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url | escape }}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "{{ site.title | escape }}",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "{{ site.avatar | absolute_url | escape }}"
+    }
+  },
+  {% if page.image %}
+  "image": {
+    "@type": "ImageObject",
+    "url": "{% if page.image.path %}{{ page.image.path | absolute_url | escape }}{% else %}{{ page.image | absolute_url | escape }}{% endif %}",
+    "width": 1200,
+    "height": 630
+  }
+  {% else %}
+  "image": {
+    "@type": "ImageObject",
+    "url": "{{ site.social_preview_image | absolute_url | escape }}",
+    "width": 1200,
+    "height": 630
+  }
+  {% endif %}
+}
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,180 @@
+{% include structured-data.html %}
+---
+layout: default
+refactor: true
+panel_includes:
+  - toc
+tail_includes:
+  - related-posts
+  - post-nav
+script_includes:
+  - comment
+---
+
+{% include lang.html %}
+
+{% include toc-status.html %}
+
+<article class="px-1" data-toc="{{ enable_toc }}">
+  <header>
+    <h1 data-toc-skip>{{ page.title }}</h1>
+    {% if page.description %}
+      <p class="post-desc fw-light mb-4">{{ page.description }}</p>
+    {% endif %}
+
+    <div class="post-meta text-muted">
+      <!-- published date -->
+      <span>
+        {{ site.data.locales[lang].post.posted }}
+        {% include datetime.html date=page.date tooltip=true lang=lang %}
+      </span>
+
+      <!-- lastmod date -->
+      {% if page.last_modified_at and page.last_modified_at != page.date %}
+        <span>
+          {{ site.data.locales[lang].post.updated }}
+          {% include datetime.html date=page.last_modified_at tooltip=true lang=lang %}
+        </span>
+      {% endif %}
+
+      {% if page.image %}
+        {% capture src %}src="{{ page.image.path | default: page.image }}"{% endcapture %}
+        {% capture class %}class="preview-img{% if page.image.no_bg %}{{ ' no-bg ' }}{% endif %}"{% endcapture %}
+        {% capture alt %}alt="{{ page.image.alt | xml_escape | default: "Preview Image" }}"{% endcapture %}
+
+        {% if page.image.lqip %}
+          {%- capture lqip -%}lqip="{{ page.image.lqip }}"{%- endcapture -%}
+        {% endif %}
+
+        <div class="mt-3 mb-3">
+          <img {{ src }} {{ class }} {{ alt }} w="1200" h="630" {{ lqip }}>
+          {%- if page.image.alt -%}
+            <figcaption class="text-center pt-2 pb-2">{{ page.image.alt }}</figcaption>
+          {%- endif -%}
+        </div>
+      {% endif %}
+
+      <div class="d-flex justify-content-between">
+        <!-- author(s) -->
+        <span>
+          {% if page.author %}
+            {% assign authors = page.author %}
+          {% elsif page.authors %}
+            {% assign authors = page.authors %}
+          {% endif %}
+
+          {{ site.data.locales[lang].post.written_by }}
+
+          <em>
+            {% if authors %}
+              {% for author in authors %}
+                {% if site.data.authors[author].url -%}
+                  <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                {%- else -%}
+                  {{ site.data.authors[author].name }}
+                {%- endif %}
+                {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
+              {% endfor %}
+            {% else %}
+              <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>
+            {% endif %}
+          </em>
+        </span>
+
+        <div>
+          <!-- pageviews -->
+          {% if site.pageviews.provider and site.analytics[site.pageviews.provider].id %}
+            <span>
+              <em id="pageviews">
+                <i class="fas fa-spinner fa-spin small"></i>
+              </em>
+              {{ site.data.locales[lang].post.pageview_measure }}
+            </span>
+          {% endif %}
+
+          <!-- read time -->
+          {% include read-time.html content=content prompt=true lang=lang %}
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {% if enable_toc %}
+    <div id="toc-bar" class="d-flex align-items-center justify-content-between invisible">
+      <span class="label text-truncate">{{ page.title }}</span>
+      <button type="button" class="toc-trigger btn me-1">
+        <i class="fa-solid fa-list-ul fa-fw"></i>
+      </button>
+    </div>
+
+    <button id="toc-solo-trigger" type="button" class="toc-trigger btn btn-outline-secondary btn-sm">
+      <span class="label ps-2 pe-1">{{- site.data.locales[lang].panel.toc -}}</span>
+      <i class="fa-solid fa-angle-right fa-fw"></i>
+    </button>
+
+    <dialog id="toc-popup" class="p-0">
+      <div class="header d-flex flex-row align-items-center justify-content-between">
+        <div class="label text-truncate py-2 ms-4">{{- page.title -}}</div>
+        <button id="toc-popup-close" type="button" class="btn mx-1 my-1 opacity-75">
+          <i class="fas fa-close"></i>
+        </button>
+      </div>
+      <div id="toc-popup-content" class="px-4 py-3 pb-4"></div>
+    </dialog>
+  {% endif %}
+
+  <div class="content">
+    {{ content }}
+  </div>
+
+  <div class="post-tail-wrapper text-muted">
+    <!-- categories -->
+    {% if page.categories.size > 0 %}
+      <div class="post-meta mb-3">
+        <i class="far fa-folder-open fa-fw me-1"></i>
+        {% for category in page.categories %}
+          <a href="{{ site.baseurl }}/categories/{{ category | slugify | url_encode }}/">{{ category }}</a>
+          {%- unless forloop.last -%},{%- endunless -%}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <!-- tags -->
+    {% if page.tags.size > 0 %}
+      <div class="post-tags">
+        <i class="fa fa-tags fa-fw me-1"></i>
+        {% for tag in page.tags %}
+          <a
+            href="{{ site.baseurl }}/tags/{{ tag | slugify | url_encode }}/"
+            class="post-tag no-text-decoration"
+          >
+            {{- tag -}}
+          </a>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div
+      class="
+        post-tail-bottom
+        d-flex justify-content-between align-items-center mt-5 pb-2
+      "
+    >
+      <div class="license-wrapper">
+        {% if site.data.locales[lang].copyright.license.template %}
+          {% capture _replacement %}
+        <a href="{{ site.data.locales[lang].copyright.license.link }}">
+          {{ site.data.locales[lang].copyright.license.name }}
+        </a>
+        {% endcapture %}
+
+          {{ site.data.locales[lang].copyright.license.template | replace: ':LICENSE_NAME', _replacement }}
+        {% endif %}
+      </div>
+
+      {% include post-sharing.html lang=lang %}
+    </div>
+    <!-- .post-tail-bottom -->
+  </div>
+  <!-- div.post-tail-wrapper -->
+</article>

--- a/_posts/2025-03-19-Cloud_Security_Learning_Roadmap.md
+++ b/_posts/2025-03-19-Cloud_Security_Learning_Roadmap.md
@@ -3,6 +3,8 @@ title: "Cloud Security Learning Roadmap (AWS, Azure, GCP))"
 date: 2025-03-19 11:39:16 +0530
 categories: [Certification, Security]
 tags: [Certification, CloudSec]
+description: This post outlines a 12-month learning roadmap for cloud security across AWS, Azure, and GCP, starting with cloud basics and progressing to advanced topics like multi-cloud security and DevSecOps.
+keywords: [Certification, Security, CloudSec, AWS, Azure, GCP, Cloud Security, Learning Roadmap, Cybersecurity, IT Training]
 ---
 
 
@@ -115,7 +117,7 @@ tags: [Certification, CloudSec]
 
 ---
 
-![Cloud Computing Diagram](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Cloud_computing_icon.svg/800px-Cloud_computing_icon.svg.png)
+![Diagram illustrating cloud computing concepts including IaaS, PaaS, SaaS, and shared responsibility model, relevant to a cloud security learning roadmap.](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/Cloud_computing_icon.svg/800px-Cloud_computing_icon.svg.png)
 
 *Figure:* Simplified cloud computing diagram showing users accessing shared apps and data in the cloud. Early on, focus on core cloud concepts (IaaS/PaaS/SaaS, virtualization, shared responsibility) before diving into security details.
 

--- a/_posts/2025-04-11-Firewall_Fundamentals.md
+++ b/_posts/2025-04-11-Firewall_Fundamentals.md
@@ -3,6 +3,8 @@ title: "Firewalls: Still Your Network's Bouncer in 2025 (And How Not to Mess It 
 date: 2025-04-11 13:09:56 +0530
 categories: [Firewall, Security, Network]
 tags: [Network Security, Firewall, Network Architecture]
+description: Firewalls are foundational to cybersecurity. This post discusses what they do, smart deployment strategies, best practices, and current trends like AI and Zero Trust in firewall technology.
+keywords: [Network Security, Firewall, Network Architecture, Cybersecurity, NGFW, Firewall Best Practices, Security, Network]
 ---
 
 Alright team, let's talk firewalls.

--- a/_posts/2025-04-20-NSPM_Comparison.md
+++ b/_posts/2025-04-20-NSPM_Comparison.md
@@ -3,6 +3,8 @@ title: "Geek's Guide: Algosec vs. Tufin vs. FireMon - Which NSPM Doesn't Suck?"
 date: 2025-04-20 21:59:56 +0530
 categories: [Security, Network] # AI tag felt a bit forced here
 tags: [Network, Security, Firewall, NSPM, Comparison, Tools] # More relevant tags
+description: This post provides a geek's guide to Network Security Policy Management (NSPM) tools, comparing Algosec, Tufin, and FireMon. It covers their core focuses, pros, cons, and helps you decide which might be the best fit for your network challenges.
+keywords: [Security, Network, Firewall, NSPM, Comparison, Tools, Algosec, Tufin, FireMon, Network Security Policy Management, Firewall Management]
 ---
 
 ## The TL;DR: Algosec vs. Tufin vs. FireMon

--- a/_posts/2025-04-21-AI_in_IT_Infrastructure_and_Cybersecurity.md
+++ b/_posts/2025-04-21-AI_in_IT_Infrastructure_and_Cybersecurity.md
@@ -3,6 +3,8 @@ title: "AI in IT Infrastructure and Cybersecurity: What's Real, What's Hype, and
 date: 2025-04-21 20:30:56 +0530 # Okay, maybe not 2025, but let's roll with it
 categories: [Security, AI]
 tags: [Network, Security, AI, HandsOn, Tools] # Added some more relevant tags
+description: AI is increasingly impacting IT infrastructure and cybersecurity. This post explores what's real versus hype, discusses practical AI tools for threat detection, incident response, and AIOps, and offers advice for engineers on leveraging AI effectively.
+keywords: [Security, AI, Network, HandsOn, Tools, Artificial Intelligence, Cybersecurity, AIOps, Machine Learning, Threat Detection, IT Infrastructure]
 ---
 
 ## TL;DR
@@ -19,7 +21,7 @@ Alright, let's cut to the chase. AI is barging into IT and security, and it's no
 Basically, AI is becoming another tool in our arsenal. It won't replace us (yet!), but it *can* make us better if we know how to use it and don't just trust the marketing slides.
 
 ---
-![Desktop View](/assets/img/posts/AIinCyberSec.png){: width="972" height="589" }
+![Conceptual image depicting AI in IT infrastructure and cybersecurity, showing network connections and data analysis.](/assets/img/posts/AIinCyberSec.png){: width="972" height="589" }
 _AI in IT Infrastructure and Cybersecurity_
 
 ## Setting the Scene: Why We're Even Talking About AI

--- a/_posts/2025-04-24-Firewall_Compliance.md
+++ b/_posts/2025-04-24-Firewall_Compliance.md
@@ -5,6 +5,8 @@ date: 2025-04-24 21:01:56 +0530
 categories: [Compliance, Security, Firewall]
 tags: [Network, Security, Firewall, Compliance, Audit, Best Practices]
 pin: true
+description: Ensuring firewall compliance is critical, going beyond just having a firewall. This post delves into the importance of firewall compliance, key standards (PCI DSS, ISO 27001, HIPAA), organizational responsibilities, change control, hardening techniques, and essential tools for maintaining a secure and compliant network.
+keywords: [Compliance, Security, Firewall, Network, Audit, Best Practices, Firewall Compliance, PCI DSS, ISO 27001, HIPAA, Network Security]
 ---
 
 Alright, let's talk firewalls. We all know they're the digital bouncers at the door of our networks – the first line of defense against the chaos outside. But just *having* a firewall isn't enough. Making sure these critical boxes are configured tightly, managed sanely, and actually *comply* with the relevant standards? That's not just good hygiene; it's often demanded by law, regulators, and your customers. Ignoring firewall compliance is like leaving the vault door open and hoping for the best.

--- a/_posts/2025-04-26-is_Zscaler_for_you.md
+++ b/_posts/2025-04-26-is_Zscaler_for_you.md
@@ -3,6 +3,8 @@ title: "Cloud Security Overhaul: Is Zscaler the Right Move for Your IT Company?"
 date: 2025-04-26 09:59:56 +0530
 categories: [Security, Connectivity]
 tags: [Network, Security, Solutions]
+description: This post explores whether Zscaler is the right cloud security solution for large IT companies, particularly in India. It discusses the challenges of securing a distributed workforce, Zscaler's core offerings (ZIA, ZPA, ZDX), deployment considerations, pricing, benefits, and potential hurdles.
+keywords: [Security, Connectivity, Network, Solutions, Zscaler, Cloud Security, SASE, Zero Trust, ZIA, ZPA, Network Transformation]
 ---
 
 Hey Tech Leaders and Security Pros!

--- a/_posts/2025-04-27-Zero_Trust_Fundamentals.md
+++ b/_posts/2025-04-27-Zero_Trust_Fundamentals.md
@@ -3,6 +3,8 @@ title: "Why Zero Trust is Your Network's New Best Friend"
 date: 2025-04-27 16:19:56 +0530
 categories: [Firewall, Security, Network]
 tags: [Network Security, Firewall, Network Architecture]
+description: This post explains why the traditional perimeter-based security model is broken and why Zero Trust Architecture (ZTA) is essential for modern cybersecurity. It covers the core principles of Zero Trust, its adoption across industries like healthcare and finance, practical implementation steps, key tools, and the future of this security framework.
+keywords: [Firewall, Security, Network, Network Security, Zero Trust, Network Architecture, ZTNA, Cybersecurity, Microsegmentation]
 ---
 # TL;DR:
 

--- a/_posts/2025-04-30-security_architecture_fundamentals.md
+++ b/_posts/2025-04-30-security_architecture_fundamentals.md
@@ -3,6 +3,8 @@ title: "Security Architecture: Principles for Designing Secure Systems and Netwo
 date: 2025-04-30 01:56:19 +0530
 categories: [Architecture, Security, Network]
 tags: [Network Security, Architecture]
+description: This post explains security architecture as the blueprint for digital fortresses, covering core principles like defense in depth, least privilege, and Zero Trust. It discusses firewalls, secure networking, compliance (GDPR, HIPAA, ISO 27001), IAM, threat modeling, incident response, and cloud security best practices.
+keywords: [Architecture, Security, Network, Network Security, Security Architecture, Secure Design, Cybersecurity, Defense in Depth, IAM]
 ---
 
 # Security Architecture: Principles for Designing Secure Systems and Networks
@@ -22,8 +24,8 @@ Welcome to the world of **Security Architecture**, where paranoia isn't a flaw�
 - Compliance isn’t optional—design with it in mind.
 
 ---
-![light mode only](assets/img/posts/Secure_Architecture.png){: .light .w-75 .shadow .rounded-10 w='700' h='668' }
-![dark mode only](assets/img/posts/Secure_Architecture_Dark.png){: .dark .w-75 .shadow .rounded-10 w='700' h='668' }
+![Diagram illustrating security architecture principles with interconnected components representing defense in depth, for light mode.](assets/img/posts/Secure_Architecture.png){: .light .w-75 .shadow .rounded-10 w='700' h='668' }
+![Diagram illustrating security architecture principles with interconnected components representing defense in depth, for dark mode.](assets/img/posts/Secure_Architecture_Dark.png){: .dark .w-75 .shadow .rounded-10 w='700' h='668' }
 
 ## What Is Security Architecture, Really?
 

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -2,6 +2,7 @@
 # the default layout is 'page'
 icon: fas fa-info-circle
 order: 4
+description: Learn more about Sudhir Dubey and the FortMatrix logs blog, focusing on cybersecurity, cloud security, and technical writing.
 ---
 
 # Hi there 👋, I'm Sudhir!

--- a/_tabs/archives.md
+++ b/_tabs/archives.md
@@ -2,4 +2,5 @@
 layout: archives
 icon: fas fa-archive
 order: 3
+description: Explore the archives of FortMatrix logs. Browse posts by date and find articles on cybersecurity, cloud security, and more.
 ---

--- a/_tabs/categories.md
+++ b/_tabs/categories.md
@@ -2,4 +2,5 @@
 layout: categories
 icon: fas fa-stream
 order: 1
+description: Browse posts on FortMatrix logs by category. Find content related to specific areas of cybersecurity, cloud technologies, and technical topics.
 ---

--- a/_tabs/tags.md
+++ b/_tabs/tags.md
@@ -2,4 +2,5 @@
 layout: tags
 icon: fas fa-tags
 order: 2
+description: Discover posts on FortMatrix logs using tags. Navigate through various keywords related to cybersecurity, cloud, certifications, and specific tools.
 ---

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.url }}/sitemap.xml


### PR DESCRIPTION
Improve SEO for Jekyll site

This commit implements several SEO enhancements:

1.  **Meta Descriptions:** I added unique `description` front matter to all posts in `_posts` and pages in `_tabs`. This provides more relevant snippets for search engine results.

2.  **Image Alt Text:** I updated image alt text in posts to be more descriptive, improving accessibility and image SEO. I found and updated images in:
    *   `_posts/2025-03-19-Cloud_Security_Learning_Roadmap.md`
    *   `_posts/2025-04-21-AI_in_IT_Infrastructure_and_Cybersecurity.md`
    *   `_posts/2025-04-30-security_architecture_fundamentals.md`

3.  **Article Schema Markup:** I added JSON-LD structured data for `Article` schema to blog posts. This was achieved by:
    *   Creating `_includes/structured-data.html` with the schema template.
    *   Creating `_layouts/post.html` (overriding the theme's default) to include the `structured-data.html` at the top of post pages.

4.  **Meta Keywords:** I added a `keywords` field to the front matter of all posts. To make these keywords functional:
    *   I created `_includes/head.html` (overriding the theme's default).
    *   I added logic to this `head.html` to generate a `<meta name="keywords" ...>` tag using the `page.keywords` list.

5.  **Robots.txt & Sitemap:**
    *   The `jekyll-seo-tag` plugin already generates `sitemap.xml`.
    *   I created a `robots.txt` file in the site root to allow all crawlers and explicitly point to `/sitemap.xml`.