### PR TITLE
Fix: Resolve post rendering issue and ensure sitemap generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,14 @@ lang: en
 # Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
 timezone: Asia/Kolkata
 
-plugins: []
+plugins:
+  - jekyll-paginate
+  - jekyll-seo-tag
+  - jekyll-archives
+  - jekyll-sitemap
+  - jekyll-include-cache
+  - jekyll-feed
+
 
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
 # ↓ --------------------------


### PR DESCRIPTION
Restored the necessary Jekyll plugins to `_config.yml`. The previous change to `_config.yml` (setting `plugins: []`) disabled default theme plugins, causing posts to render as raw markdown.

The `plugins` array in `_config.yml` has been updated to include:
- jekyll-paginate
- jekyll-seo-tag
- jekyll-archives
- jekyll-sitemap
- jekyll-include-cache
- jekyll-feed

This ensures that the Chirpy theme's dependent plugins are active, allowing posts to render correctly. It also ensures that `jekyll-feed` and `jekyll-sitemap` (added previously) are active.
